### PR TITLE
Improved ant targets

### DIFF
--- a/fr.mvanbesien.calendars/ant/build.xml
+++ b/fr.mvanbesien.calendars/ant/build.xml
@@ -1,56 +1,70 @@
 <?xml version="1.0"?>
-<project name="calendars-packager" default="main" basedir="./..">
-	<!-- $Id: build.xml,v 1.1 2008/11/05 08:53:48 maxence Exp $ -->
-	<target name="main" depends="prepare,build-core,build-disp-cal,build-disp-sol" />
+<project name="calendars-packager" default="main" basedir="..">
+  <!-- $Id: build.xml,v 1.1 2008/11/05 08:53:48 maxence Exp $ -->
+  <target name="main" depends="build-core, build-disp-cal, build-disp-sol" />
 
-	<target name="prepare">
-		<echo message="Calendars Packager" />
-		<property name="build.dir" value="${basedir}/target/build" />
-		<property name="classes.dir" value="${basedir}/target/classes" />
-		<property name="version" value="2.6.0" />
-		<mkdir dir="${build.dir}" />
-		<echo message="Basedir is: ${basedir}" />
-	</target>
+  <target name="-prepare">
+    <echo message="Calendars Packager" />
+    <property name="build.dir" value="target/build" />
+    <property name="classes.dir" value="target/classes" />
+    <property name="version" value="2.6.0" />
+    <mkdir dir="${build.dir}" />
+    <mkdir dir="${classes.dir}" />
+    <echo message="Build dir is: ${build.dir}" />
+    <echo message="Class dir is: ${classes.dir}" />
+  </target>
 
-	<target name="build-core">
-		<jar destfile="${build.dir}/calendars-core-${version}.jar">
-			<fileset dir="${classes.dir}">
-				<include name="fr/mvanbesien/calendars/calendars/*.class" />
-				<include name="fr/mvanbesien/calendars/clocks/*.class" />
-				<include name="fr/mvanbesien/calendars/dates/*.class" />
-				<include name="fr/mvanbesien/calendars/days/*.class" />
-				<include name="fr/mvanbesien/calendars/ephemerides/*.class" />
-				<include name="fr/mvanbesien/calendars/tools/*.class" />
-				<include name="**/*.properties" />
-			</fileset>
-			<fileset dir="${basedir}">
-				<include name="images/**/*.gif" />
-			</fileset>
-		</jar>
-	</target>
+  <target name="-compile" depends="-prepare">
+    <javac debug="true" debuglevel="lines,vars,source"
+           srcdir="src/main/java" destdir="${classes.dir}" includeantruntime="false" />
+  </target>
 
-	<target name="build-disp-cal">
-		<jar destfile="${build.dir}/calendars-caldisp-${version}.jar">
-			<manifest>
-				<attribute name="Class-Path" value="calendars-core-${version}.jar" />
-				<attribute name="Main-Class" value="fr.mvanbesien.calendars.runners.CalendarsDisplayer" />
-			</manifest>
-			<fileset dir="${classes.dir}">
-				<include name="fr/beziencorp/calendars/runners/CalendarsDisplayer.class" />
-			</fileset>
-		</jar>
-	</target>
+  <target name="build-core" depends="-compile">
+    <jar destfile="${build.dir}/calendars-core-${version}.jar">
+      <fileset dir="${classes.dir}">
+        <include name="**/*.class" />
+      </fileset>
+      <fileset dir="src/main/resources">
+        <include name="**/*.properties" />
+      </fileset>
+    </jar>
+  </target>
 
-	<target name="build-disp-sol">
-		<jar destfile="${build.dir}/calendars-soldisp-${version}.jar">
-			<manifest>
-				<attribute name="Class-Path" value="calendars-core-${version}.jar" />
-				<attribute name="Main-Class" value="fr.mvanbesien.calendars.runners.SolarDisplayer" />
-			</manifest>
-			<fileset dir="${classes.dir}">
-				<include name="fr/beziencorp/calendars/runners/SolarDisplayer.class" />
-			</fileset>
-		</jar>
-	</target>
+  <target name="build-disp-cal" depends="build-core">
+    <jar destfile="${build.dir}/calendars-caldisp-${version}.jar">
+      <manifest>
+        <attribute name="Class-Path" value="calendars-core-${version}.jar" />
+        <attribute name="Main-Class" value="fr.mvanbesien.calendars.runners.CalendarsDisplayer" />
+      </manifest>
+      <fileset dir="${classes.dir}">
+        <include name="fr/mvanbesien/calendars/runners/CalendarsDisplayer.class" />
+      </fileset>
+    </jar>
+  </target>
 
+  <target name="build-disp-sol" depends="build-core">
+    <jar destfile="${build.dir}/calendars-soldisp-${version}.jar">
+      <manifest>
+        <attribute name="Class-Path" value="calendars-core-${version}.jar" />
+        <attribute name="Main-Class" value="fr.mvanbesien.calendars.runners.SolarDisplayer" />
+      </manifest>
+      <fileset dir="${classes.dir}">
+        <include name="fr/mvanbesien/calendars/runners/SolarDisplayer.class" />
+      </fileset>
+    </jar>
+  </target>
+
+  <target name="run.sol" depends="build-disp-sol">
+    <java classname="fr.mvanbesien.calendars.runners.SolarDisplayer"
+          classpath="${build.dir}/calendars-soldisp-${version}.jar" />
+  </target>
+
+  <target name="run.cal" depends="build-disp-cal">
+    <java classname="fr.mvanbesien.calendars.runners.CalendarsDisplayer"
+          classpath="${build.dir}/calendars-caldisp-${version}.jar" />
+  </target>
+
+  <target name="clean">
+    <delete dir="target" deleteonexit="true" verbose="false" />
+  </target>
 </project>


### PR DESCRIPTION
A couple of changes are introduced.
${classes.dir} needs to be created before the 'build-core' can start.
There was no <javac> task called, it is now.
There is no need to include ${basedir}, it is implicit.
The resource files (*.properties) were not included in build-core's jar, instead some in-existing *.gif files.
The class files were added one package a time, now they are added recursively with 1 inclusion.
A clean and 2 runner targets are added, too.
There were no dependencies in the targets "build-core", "build-disp-cal" or build-disp-sol"; the assumption was that you always run "main", implicitly.
The target "prepare" was callable, which should have been a private target IMHO.
